### PR TITLE
Add side navigation drawer with links

### DIFF
--- a/src/components/SideNavDrawer.vue
+++ b/src/components/SideNavDrawer.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-navigation-drawer permanent clipped>
+    <v-list>
+      <v-list-item
+        v-for="item in items"
+        :key="item.title"
+        :to="item.route"
+      >
+        <v-list-item-icon>
+          <v-icon>{{ item.icon }}</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title>{{ item.title }}</v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </v-navigation-drawer>
+</template>
+
+<script setup lang="ts">
+const items = [
+  { title: 'Products', icon: 'mdi-package-variant', route: '/products' },
+  { title: 'Orders', icon: 'mdi-cart', route: '/orders' },
+  { title: 'Picking', icon: 'mdi-hand-pointing-right', route: '/picking' },
+  { title: 'Shipping', icon: 'mdi-truck', route: '/shipping' },
+  { title: 'Invoices', icon: 'mdi-file-document', route: '/invoices' },
+]
+</script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app>
+    <SideNavDrawer />
     <v-main>
       <router-view />
     </v-main>
@@ -9,5 +10,5 @@
 </template>
 
 <script lang="ts" setup>
-  //
+import SideNavDrawer from '@/components/SideNavDrawer.vue'
 </script>

--- a/src/pages/Invoices.vue
+++ b/src/pages/Invoices.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Invoices</h1>
+    <p>This is the Invoices page.</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  //
+</script>

--- a/src/pages/Orders.vue
+++ b/src/pages/Orders.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Orders</h1>
+    <p>This is the Orders page.</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  //
+</script>

--- a/src/pages/Picking.vue
+++ b/src/pages/Picking.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Picking</h1>
+    <p>This is the Picking page.</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  //
+</script>

--- a/src/pages/Products.vue
+++ b/src/pages/Products.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Products</h1>
+    <p>This is the Products page.</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  //
+</script>

--- a/src/pages/Shipping.vue
+++ b/src/pages/Shipping.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Shipping</h1>
+    <p>This is the Shipping page.</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  //
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,7 +11,14 @@ import { routes } from 'vue-router/auto-routes'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: setupLayouts(routes),
+  routes: setupLayouts([
+    ...routes,
+    { path: '/products', component: () => import('@/pages/Products.vue') },
+    { path: '/orders', component: () => import('@/pages/Orders.vue') },
+    { path: '/picking', component: () => import('@/pages/Picking.vue') },
+    { path: '/shipping', component: () => import('@/pages/Shipping.vue') },
+    { path: '/invoices', component: () => import('@/pages/Invoices.vue') },
+  ]),
 })
 
 // Workaround for https://github.com/vitejs/vite/issues/11804


### PR DESCRIPTION
Add a side navigation drawer with links to "Products", "Orders", "Picking", "Shipping", and "Invoices" using Vuetify components.

* **SideNavDrawer Component**
  - Define a `v-navigation-drawer` component with links to "Products", "Orders", "Picking", "Shipping", and "Invoices"
  - Use Vuetify icons for each link

* **Default Layout**
  - Import and include the `SideNavDrawer` component inside the `v-app` component

* **Router**
  - Add routes for "Products", "Orders", "Picking", "Shipping", and "Invoices"

* **Pages**
  - Create placeholder components for "Products", "Orders", "Picking", "Shipping", and "Invoices" pages

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/ui-vue-retailapp?shareId=8de004dc-75ac-4dec-a1a4-ca551f46116b).