### PR TITLE
Update SideNavDrawer to align icon and title, add hover effect

### DIFF
--- a/src/components/SideNavDrawer.vue
+++ b/src/components/SideNavDrawer.vue
@@ -1,19 +1,22 @@
 <template>
   <v-navigation-drawer permanent clipped>
-    <v-list>
-      <v-list-item
-        v-for="item in items"
-        :key="item.title"
-        :to="item.route"
-      >
-        <v-list-item-icon>
-          <v-icon>{{ item.icon }}</v-icon>
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{ item.title }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
+    <v-list-item-group>
+      <v-list>
+        <v-list-item
+          v-for="item in items"
+          :key="item.title"
+          :to="item.route"
+          class="hover-effect"
+        >
+          <v-list-item-content>
+            <v-list-item-icon>
+              <v-icon>{{ item.icon }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-list-item-group>
   </v-navigation-drawer>
 </template>
 
@@ -26,3 +29,9 @@ const items = [
   { title: 'Invoices', icon: 'mdi-file-document', route: '/invoices' },
 ]
 </script>
+
+<style scoped>
+.hover-effect:hover {
+  background-color: lightgray;
+}
+</style>

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -8,3 +8,9 @@
 // @use 'vuetify/settings' with (
 //   $color-pack: false
 // );
+
+.hover-effect {
+  &:hover {
+    background-color: lightgray;
+  }
+}


### PR DESCRIPTION
Update the `SideNavDrawer` component to align icon and title on the same line and add hover effect to links.

* Modify `src/components/SideNavDrawer.vue`
  - Use `v-list-item-content` with `v-list-item-title` and `v-list-item-icon` on the same line.
  - Add a hover effect to `v-list-item` to change the background color to light gray.
  - Use `v-list-item-group` to manage active link styling.
  - Add scoped style for hover effect.

* Modify `src/styles/settings.scss`
  - Add a new class for the hover effect with a light gray background color.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/ui-vue-retailapp?shareId=4a5690f4-9bcb-4cda-8efc-af3cb2338076).